### PR TITLE
Docs: swagger 설정 + 토큰 갱신 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/remind/api/member/controller/MemberController.java
+++ b/src/main/java/com/remind/api/member/controller/MemberController.java
@@ -1,9 +1,12 @@
 package com.remind.api.member.controller;
 
 import com.remind.api.member.dto.request.RefreshTokenRequestDto;
+import com.remind.api.member.dto.response.TokenResponseDto;
 import com.remind.api.member.service.MemberService;
 import com.remind.core.domain.common.response.ApiSuccessResponse;
 import com.remind.core.security.dto.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,19 +19,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
+@Tag(name = "member API", description = "member 관련 API 문서")
 public class MemberController {
 
     private final MemberService memberService;
 
     //>>>>  소셜 로그인 구현 예정
     @PostMapping("/login")
-    public void login(){
+    public String login() {
+        return "login 성공";
 
     }
 
-
+    @Operation(
+            summary = "토큰 갱신 API",
+            description = "refresh token을 사용하여 access token와 refresh token을 갱신한다."
+    )
     @PostMapping("/refresh")
-    public ResponseEntity<ApiSuccessResponse<?>> refreshToken(
+    public ResponseEntity<ApiSuccessResponse<TokenResponseDto>> refreshToken(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @RequestBody RefreshTokenRequestDto dto
     ) {

--- a/src/main/java/com/remind/api/member/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/remind/api/member/dto/response/TokenResponseDto.java
@@ -1,11 +1,15 @@
 package com.remind.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "토큰 응답 model")
 public record TokenResponseDto(
-    String accessToken,
-    String refreshToken
+        @Schema(description = "access token 유효 기간: 30분")
+        String accessToken,
+        @Schema(description = "refresh token 유효 기간: 60분")
+        String refreshToken
 ) {
 
 }

--- a/src/main/java/com/remind/core/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/remind/core/infra/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.remind.core.infra.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private final String SCHEME_NAME = "Authorization";
+    private final String BEARER_FORMAT = "JWT";
+    private final String SCHEME = "Bearer";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                SCHEME_NAME, new SecurityScheme()
+                                        .name(SCHEME_NAME)
+                                        .type(Type.HTTP)
+                                        .bearerFormat(BEARER_FORMAT)
+                                        .in(In.HEADER)
+                                        .scheme(SCHEME)))
+                .info(new Info()
+                        .title("ReMind 프로젝트 API 문서")
+                        .description("큐시즘 밋업 ReMind 프로젝트 API 문서")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,12 +10,13 @@ spring:
     import: classpath:env.properties
 
   jpa:
-    show-sql: true
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        show_sql: true
 
   ## redis 설정
   data:
@@ -28,3 +29,19 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-expiration-seconds: 1800
   refresh-expiration-seconds: 3600
+
+# 쿼리문 파라미터 바인딩 값 확인
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace
+
+#custom swagger url
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+
+


### PR DESCRIPTION
## 📝 작업 내용
- Security 적용한 Swagger 설정을 추가했습니다.
- 토큰 갱신 API 문서화 추가했습니다.

## 💬 ETC.
**Reference**
- openapi 3 spring boot
  -  https://springdoc.org/
  - https://medium.com/@javedalikhan50/comprehensive-guide-to-openapi-swagger-integration-in-spring-boot-with-spring-security-jwt-edf8c84e7d91

**논의 사항**
토큰 갱신 api에서 와일드 카드를 사용하여 ResponseEntity<ApiSuccessResponse<?>>로 반환 했을 때, data 타입 T(TokenResponseDto)를 인식하지 못하여 swagger-ui에 아래와 같이 표현되는데

![image](https://github.com/Team-ReMind/ReMind-BE/assets/108208265/e1349169-d926-4b85-b272-e9ac7d21a3b8)

swagger가 인식할 수 있도록 하는 방법이 있나?

## #️⃣ 연관된 이슈
resolves: #3