### PR TITLE
Feat/7 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,17 @@ repositories {
 	mavenCentral()
 }
 
+//openFeign
+ext {
+	set('springCloudVersion', "2023.0.0")
+}
+//openFeign
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	//spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -44,6 +55,9 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// open feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 }
 

--- a/src/main/java/com/remind/api/member/controller/MemberController.java
+++ b/src/main/java/com/remind/api/member/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
 
     @Operation(
             summary = "카카오 로그인 API",
-            description = "kakao access token을 사용하여 소셜 로그인 시도"
+            description = "kakao authorization code를 이용하여 발급받은 kakao accessToken을 사용하여 소셜 로그인 합니다."
     )
     @PostMapping("/login")
     public ResponseEntity<ApiSuccessResponse<KakaoLoginResponse>> kakaoLogin(

--- a/src/main/java/com/remind/api/member/controller/MemberController.java
+++ b/src/main/java/com/remind/api/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.remind.api.member.controller;
 
+import com.remind.api.member.dto.request.KakaoLoginRequest;
+import com.remind.api.member.dto.response.KakaoLoginResponse;
 import com.remind.api.member.dto.request.RefreshTokenRequestDto;
 import com.remind.api.member.dto.response.TokenResponseDto;
 import com.remind.api.member.service.MemberService;
@@ -24,10 +26,17 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    //>>>>  소셜 로그인 구현 예정
+    @Operation(
+            summary = "카카오 로그인 API",
+            description = "kakao access token을 사용하여 소셜 로그인 시도"
+    )
     @PostMapping("/login")
-    public String login() {
-        return "login 성공";
+    public ResponseEntity<ApiSuccessResponse<KakaoLoginResponse>> kakaoLogin(
+            @RequestBody KakaoLoginRequest req
+    ) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(memberService.kakaoLogin(req))
+        );
 
     }
 

--- a/src/main/java/com/remind/api/member/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/remind/api/member/dto/request/KakaoLoginRequest.java
@@ -1,4 +1,8 @@
 package com.remind.api.member.dto.request;
 
-public record KakaoLoginRequest(String kakaoAccessToken, String redirectUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record KakaoLoginRequest(
+        @Schema(description = "카카오에서 발급받은 액세스 토큰", required = true)
+        String kakaoAccessToken) {
 }

--- a/src/main/java/com/remind/api/member/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/remind/api/member/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,4 @@
+package com.remind.api.member.dto.request;
+
+public record KakaoLoginRequest(String kakaoAccessToken, String redirectUrl) {
+}

--- a/src/main/java/com/remind/api/member/dto/response/KakaoGetMemberInfoResponse.java
+++ b/src/main/java/com/remind/api/member/dto/response/KakaoGetMemberInfoResponse.java
@@ -1,0 +1,31 @@
+package com.remind.api.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoGetMemberInfoResponse {
+    @JsonProperty("id")
+    private Long authId;
+
+    private KakaoAcountDto kakao_account;
+
+    /**
+     * kakao api 응답에 들어가는 객체
+     */
+    @Getter
+    public static class KakaoAcountDto {
+
+        private KakaoProfileDto profile;
+
+    }
+
+    @Getter
+    public static class KakaoProfileDto {
+
+        private String nickname;
+
+    }
+
+
+}

--- a/src/main/java/com/remind/api/member/dto/response/KakaoGetMemberInfoResponse.java
+++ b/src/main/java/com/remind/api/member/dto/response/KakaoGetMemberInfoResponse.java
@@ -17,13 +17,20 @@ public class KakaoGetMemberInfoResponse {
     public static class KakaoAcountDto {
 
         private KakaoProfileDto profile;
+        private String name;
+        private String email;
+        private String birthYear;
+        private String gender;
+        private String phone_number;
 
+        // 추가되는 필드
     }
 
     @Getter
     public static class KakaoProfileDto {
 
-        private String nickname;
+//        private String nickname;
+        private String profile_image_url;
 
     }
 

--- a/src/main/java/com/remind/api/member/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/remind/api/member/dto/response/KakaoLoginResponse.java
@@ -1,0 +1,11 @@
+package com.remind.api.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record KakaoLoginResponse(Long authId, String redirectUrl, String refreshToken, String accessToken, String name) {
+}
+
+
+
+

--- a/src/main/java/com/remind/api/member/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/remind/api/member/dto/response/KakaoLoginResponse.java
@@ -1,9 +1,19 @@
 package com.remind.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record KakaoLoginResponse(Long authId, String redirectUrl, String refreshToken, String accessToken, String name) {
+public record KakaoLoginResponse(@Schema(description = "Remind의 리프레시 토큰")
+                                 String refreshToken,
+
+                                 @Schema(description = "Remind의 액세스 토큰")
+                                 String accessToken,
+
+                                 @Schema(description = "사용자가 온보딩 과정을 완료했는지 여부")
+                                 Boolean isMemberFinishedOnboarding,
+                                 @Schema(description = "카카오 사용자의 본명")
+                                 String name) {
 }
 
 

--- a/src/main/java/com/remind/api/member/kakao/KakaoFeignClient.java
+++ b/src/main/java/com/remind/api/member/kakao/KakaoFeignClient.java
@@ -1,0 +1,17 @@
+package com.remind.api.member.kakao;
+
+import com.remind.api.member.dto.response.KakaoGetMemberInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-feign", url = "https://kapi.kakao.com")
+public interface KakaoFeignClient {
+
+    @GetMapping("/v2/user/me")
+//    @GetMapping("/v1/user/access_token_info")
+    public KakaoGetMemberInfoResponse getKakaoIdByAccessToken(@RequestHeader("Authorization") String kakaoAccessToken);
+
+//    @GetMapping("/v2/user/me")
+//    public KakaoGetUserInfoResponseDto getKakaoUserEmailByAccessToken(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/com/remind/api/member/kakao/KakaoFeignClient.java
+++ b/src/main/java/com/remind/api/member/kakao/KakaoFeignClient.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface KakaoFeignClient {
 
     @GetMapping("/v2/user/me")
-//    @GetMapping("/v1/user/access_token_info")
     public KakaoGetMemberInfoResponse getKakaoIdByAccessToken(@RequestHeader("Authorization") String kakaoAccessToken);
 
 //    @GetMapping("/v2/user/me")

--- a/src/main/java/com/remind/api/member/service/MemberService.java
+++ b/src/main/java/com/remind/api/member/service/MemberService.java
@@ -3,7 +3,13 @@ package com.remind.api.member.service;
 import static com.remind.core.domain.enums.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.remind.core.domain.enums.MemberErrorCode.REFRESH_TOKEN_NOT_FOUND;
 import static com.remind.core.domain.enums.MemberErrorCode.REFRESH_TOKEN_NOT_MATCH;
+
+import com.remind.api.member.dto.request.KakaoLoginRequest;
+import com.remind.api.member.dto.response.KakaoGetMemberInfoResponse;
+import com.remind.api.member.dto.response.KakaoLoginResponse;
 import com.remind.api.member.exception.MemberException;
+//import com.remind.api.member.kakao.KakaoFeignClient;
+import com.remind.api.member.kakao.KakaoFeignClient;
 import com.remind.core.domain.common.repository.RedisRepository;
 import com.remind.core.domain.member.Member;
 import com.remind.core.domain.member.repository.MemberRepository;
@@ -11,17 +17,87 @@ import com.remind.api.member.dto.response.TokenResponseDto;
 import com.remind.core.security.dto.UserDetailsImpl;
 import com.remind.core.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
 
+    private final KakaoFeignClient kakaoFeignClient;
     private final MemberRepository memberRepository;
     private final RedisRepository redisRepository;
     private final JwtProvider jwtProvider;
 
+    @Transactional
+    public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
+
+        String kakaoAccessToken = request.kakaoAccessToken();
+
+        // 카카오어세스토큰으로 카카오api호출, 카카오아이디 받아오기
+        // 그 카카오 아이디는 authId이다.
+        KakaoGetMemberInfoResponse kakaoMemberInfo = getKakaoIdByAccessToken("Bearer " + kakaoAccessToken);
+
+        log.info("nickname :: " + kakaoMemberInfo.getKakao_account().getProfile().getNickname());
+        log.info("authId :: " + kakaoMemberInfo.getAuthId());
+
+        // authId로 찾았을때 존재하지 않으면 등록해주기
+        Member member = memberRepository.findByAuthId(kakaoMemberInfo.getAuthId())
+                .orElse(null);
+
+        //authId로 등록된 유저가 아니면 가입 후 멤버 반환해주기
+        if (member == null) {
+            member = register(kakaoMemberInfo);
+        }
+
+        //해당 멤버의 authId로 jwt토큰 발급하기
+
+        //이 코드는 이해가 안돼
+        UserDetailsImpl userDetail = UserDetailsImpl.fromMember(member);
+
+        String newAccessToken = jwtProvider.createAccessToken(userDetail);
+        String newRefreshToken = jwtProvider.createRefreshToken(userDetail);
+
+
+        // redis 토큰 정보 저장
+//        redisRepository.saveToken(userDetail.getMemberId(), newRefreshToken);
+
+        return KakaoLoginResponse.builder()
+                .authId(kakaoMemberInfo.getAuthId())
+                .redirectUrl(request.redirectUrl())
+                .name(kakaoMemberInfo.getKakao_account().getProfile().getNickname())
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+        // authId로 멤버를 찾을 때, 유저가 존재하면 jwt토큰 발급해주기
+    }
+
+    /**
+     * Bearer + kakaoAccessToken으로 카카오api를 호출하여 kakao authId를 받아오는 로직
+     * @param kakaoAccessToken
+     * @return
+     */
+    private KakaoGetMemberInfoResponse getKakaoIdByAccessToken(String kakaoAccessToken) {
+        return kakaoFeignClient.getKakaoIdByAccessToken(kakaoAccessToken);
+    }
+
+    /**
+     * 카카오 로그인 authId가 존재하지 않는 경우 가입하는 로직
+     * @param kakaoMemberInfo
+     * @return
+     */
+    private Member register(KakaoGetMemberInfoResponse kakaoMemberInfo) {
+        Member member = Member.builder()
+                .authId(kakaoMemberInfo.getAuthId())
+                .name(kakaoMemberInfo.getKakao_account().getProfile().getNickname())
+                .build();
+
+        return memberRepository.save(member);
+
+
+    }
 
     //TODO: NoSql인 redis의 경우, @Transactional을 붙여야하는지 확인
     @Transactional

--- a/src/main/java/com/remind/api/member/service/MemberService.java
+++ b/src/main/java/com/remind/api/member/service/MemberService.java
@@ -62,7 +62,7 @@ public class MemberService {
 
 
         // redis 토큰 정보 저장
-//        redisRepository.saveToken(userDetail.getMemberId(), newRefreshToken);
+        redisRepository.saveToken(userDetail.getMemberId(), newRefreshToken);
 
         return KakaoLoginResponse.builder()
                 .authId(kakaoMemberInfo.getAuthId())

--- a/src/main/java/com/remind/core/domain/enums/MemberErrorCode.java
+++ b/src/main/java/com/remind/core/domain/enums/MemberErrorCode.java
@@ -9,7 +9,9 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     REFRESH_TOKEN_NOT_FOUND(404, "해당 memberId로 저장된 refresh token이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     REFRESH_TOKEN_NOT_MATCH(404, "저장된 refresh token 값과 일치하지 않습니다.", HttpStatus.NOT_FOUND),
-    MEMBER_NOT_FOUND(404, "일치하는 member가 없습니다.", HttpStatus.NOT_FOUND);
+    MEMBER_NOT_FOUND(404, "일치하는 member가 없습니다.", HttpStatus.NOT_FOUND),
+    AUTH_ID_NOT_FOUND(404, "kakao auth id와 일치하는 member가 없습니다.", HttpStatus.NOT_FOUND),
+    ;
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/remind/core/domain/member/Member.java
+++ b/src/main/java/com/remind/core/domain/member/Member.java
@@ -31,13 +31,17 @@ public class Member {
 
     private String name;
 
-    private String age;
+    private int age;
 
     private String gender;
 
     private String email;
 
     private String phoneNumber;
+
+    private String profileImageUrl;
+
+    private Boolean isOnboardingFinished;
 
     @Enumerated(value = EnumType.STRING)
     private RolesType rolesType;

--- a/src/main/java/com/remind/core/domain/member/Member.java
+++ b/src/main/java/com/remind/core/domain/member/Member.java
@@ -31,6 +31,14 @@ public class Member {
 
     private String name;
 
+    private String age;
+
+    private String gender;
+
+    private String email;
+
+    private String phoneNumber;
+
     @Enumerated(value = EnumType.STRING)
     private RolesType rolesType;
 

--- a/src/main/java/com/remind/core/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/remind/core/domain/member/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package com.remind.core.domain.member.repository;
 import com.remind.core.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    Optional<Member> findByAuthId(Long authId);
 }

--- a/src/main/java/com/remind/core/infra/config/FeignClientConfig.java
+++ b/src/main/java/com/remind/core/infra/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package com.remind.core.infra.config;
+
+import com.remind.RemindApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackageClasses = RemindApplication.class)
+@Configuration
+public class FeignClientConfig {
+}


### PR DESCRIPTION
- 프론트에서 `kakaoAccessToken`을 전달받아 소셜로그인을 시도합니다.
- `OpenFeign`을 사용하여 카카오API를 호출하여 카카오 `auth Id`를 db에 저장된 정보와 비교합니다
- 존재하는 authId가 없으면 가입시킵니다.
- `redis`에 rt를 저장합니다

### Todo
- PR템플릿 추가
- NCP Server에 Redis 설치
- 