### PR TITLE
Fix/17: 서버 환경에서 .env 파일 인식 못하는 오류 해결

### DIFF
--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -10,3 +10,7 @@ services:
       - 8080:8080
     environment:
       - TZ=Asia/Seoul
+    volumes:
+      - type: bind
+        source: /root/.env
+        target: /.env


### PR DESCRIPTION
## 📝 작업 내용
 - docker-compose 실행 시, 서버 file system에 존재하는 .env 파일 인식하지 못하는 에러를 해결했습니다.

## 💬 ETC.
 - docker bind mount를 사용하여 컨테이너 외부의 호스트 파일 시스템(.env)를 인식하도록 수정했습니다.

## #️⃣ 연관된 이슈
close: #17
