### PR TITLE
fix: docker compose file 버전 문제 해결

### DIFF
--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 services:
   remind:
     image: ${NCP_CONTAINER_REGISTRY_PUBLIC_ENDPOINT}/${NCP_CONTAINER_REGISTRY_IMAGE}

--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
   remind:
     image: ${NCP_CONTAINER_REGISTRY_PUBLIC_ENDPOINT}/${NCP_CONTAINER_REGISTRY_IMAGE}


### PR DESCRIPTION
## 📝 작업 내용
 - docker compose 파일 버전 문제를 해결했습니다.
    - version와 문법 호환성 문제로 현재의 docker-compose file은 version 3.2부터 호환 가능합니다.
    - 추후 공식 문서에서는 version을 삭제하는 것을 권장해서 docker-compose 파일에서 version에 대한 정보를 삭제했습니다.

## 💬 ETC.
**Reference**
- https://github.com/docker/compose/issues/4763
- https://docs.docker.com/compose/compose-file/04-version-and-name/

## #️⃣ 연관된 이슈
close: #19
