### PR TITLE
Feature/12 오늘의 기분 API 추가 + 무트 차트 페이지네이션 추가

### DIFF
--- a/src/main/java/com/remind/api/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/com/remind/api/member/exception/MemberExceptionHandler.java
@@ -2,6 +2,7 @@ package com.remind.api.member.exception;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
+import com.remind.core.domain.common.exception.MemberException;
 import com.remind.core.domain.common.response.ErrorResponse;
 import com.remind.core.domain.enums.MemberErrorCode;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/remind/api/member/service/MemberService.java
+++ b/src/main/java/com/remind/api/member/service/MemberService.java
@@ -7,8 +7,7 @@ import static com.remind.core.domain.enums.MemberErrorCode.REFRESH_TOKEN_NOT_MAT
 import com.remind.api.member.dto.request.KakaoLoginRequest;
 import com.remind.api.member.dto.response.KakaoGetMemberInfoResponse;
 import com.remind.api.member.dto.response.KakaoLoginResponse;
-import com.remind.api.member.exception.MemberException;
-//import com.remind.api.member.kakao.KakaoFeignClient;
+import com.remind.core.domain.common.exception.MemberException;
 import com.remind.api.member.kakao.KakaoFeignClient;
 import com.remind.core.domain.common.repository.RedisRepository;
 import com.remind.core.domain.member.Member;

--- a/src/main/java/com/remind/api/mood/controller/ActivityController.java
+++ b/src/main/java/com/remind/api/mood/controller/ActivityController.java
@@ -1,0 +1,57 @@
+package com.remind.api.mood.controller;
+
+import com.remind.api.mood.dto.request.ActivitySaveRequestDto;
+import com.remind.api.mood.dto.response.ActivityListResponseDto;
+import com.remind.api.mood.service.ActivityService;
+import com.remind.core.domain.common.response.ApiSuccessResponse;
+import com.remind.core.security.dto.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/activity")
+@Tag(name = "활동 API", description = "활동 관련 API입니다.")
+public class ActivityController {
+
+    private final ActivityService activityService;
+
+    @Operation(
+            summary = "활동 추가 API"
+    )
+    @ApiResponse(
+            responseCode = "201", description = "활동 추가 성공 응답입니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(value = "{\"code\":201, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"activityId\": 1}}")
+                    }
+            )
+    )
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponse<?>> saveActivity(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody ActivitySaveRequestDto dto) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(Map.of("activityIdd", activityService.save(userDetails, dto))));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponse<ActivityListResponseDto>> getActivityList(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(new ApiSuccessResponse<>(activityService.getActivityList(userDetails)));
+    }
+
+}

--- a/src/main/java/com/remind/api/mood/controller/ActivityController.java
+++ b/src/main/java/com/remind/api/mood/controller/ActivityController.java
@@ -48,6 +48,12 @@ public class ActivityController {
                 new ApiSuccessResponse<>(Map.of("activityIdd", activityService.save(userDetails, dto))));
     }
 
+    @Operation(
+            summary = "추가한 활동 리스트 조회 API"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "추가한 활동 리스트 조회 성공 응답입니다.", useReturnTypeSchema = true
+    )
     @GetMapping
     public ResponseEntity<ApiSuccessResponse<ActivityListResponseDto>> getActivityList(
             @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/remind/api/mood/controller/MoodChartController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodChartController.java
@@ -5,6 +5,7 @@ import com.remind.api.mood.service.MoodChartService;
 import com.remind.core.domain.common.response.ApiSuccessResponse;
 import com.remind.core.security.dto.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,11 @@ public class MoodChartController {
     @GetMapping
     public ResponseEntity<ApiSuccessResponse<MoodChartPagingResponseDto>> getMoodChart(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam("year") Integer year,
-            @RequestParam("month") Integer month) {
-        return ResponseEntity.ok(new ApiSuccessResponse<>(moodChartService.getMoodChart(userDetails, year, month)));
+            @Parameter(description = "년도") @RequestParam("year") Integer year,
+            @Parameter(description = "월") @RequestParam("month") Integer month,
+            @Parameter(description = "마지막으로 조회한 일") @RequestParam("day") Integer day,
+            @Parameter(description = "한 페이지 속 데이터 갯수") @RequestParam("size") Integer size) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(moodChartService.getMoodChart(userDetails, year, month, day, size)));
     }
 }

--- a/src/main/java/com/remind/api/mood/controller/MoodChartController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodChartController.java
@@ -1,0 +1,39 @@
+package com.remind.api.mood.controller;
+
+import com.remind.api.mood.dto.response.MoodChartPagingResponseDto;
+import com.remind.api.mood.service.MoodChartService;
+import com.remind.core.domain.common.response.ApiSuccessResponse;
+import com.remind.core.security.dto.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mood/chart")
+@Tag(name = "무드 차트 API", description = "무드 차트, 기분 별 활동 차트 API입니다.")
+public class MoodChartController {
+
+    private final MoodChartService moodChartService;
+
+    @Operation(
+            summary = "무드 차트 조회"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "무드 차트 조회 성공 응답입니다.", useReturnTypeSchema = true
+    )
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponse<MoodChartPagingResponseDto>> getMoodChart(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("year") Integer year,
+            @RequestParam("month") Integer month) {
+        return ResponseEntity.ok(new ApiSuccessResponse<>(moodChartService.getMoodChart(userDetails, year, month)));
+    }
+}

--- a/src/main/java/com/remind/api/mood/controller/MoodController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodController.java
@@ -1,0 +1,71 @@
+package com.remind.api.mood.controller;
+
+import static com.remind.core.domain.enums.GlobalSuccessCode.*;
+
+import com.remind.api.mood.dto.request.MoodSaveRequestDto;
+import com.remind.api.mood.dto.response.MoodResponseDto;
+import com.remind.api.mood.service.MoodService;
+import com.remind.core.domain.common.response.ApiSuccessResponse;
+import com.remind.core.domain.enums.GlobalSuccessCode;
+import com.remind.core.security.dto.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mood")
+@Tag(name = "오늘의 기분 API", description = "오늘의 기분 관련 API입니다.")
+public class MoodController {
+
+    private final MoodService moodService;
+
+    @Operation(
+            summary = "오늘의 기분 추가 API"
+    )
+    @ApiResponse(
+            responseCode = "201", description = "오늘의 기분 추가 성공 응답입니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(value = "{\"code\":201, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"moodId\": 1}}")
+                    }
+            )
+    )
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponse<?>> create(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody MoodSaveRequestDto moodSaveRequestDto) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(Map.of("moodId", moodService.create(userDetails, moodSaveRequestDto))));
+    }
+
+    @Operation(
+            summary = "특정 날짜의 오늘의 기분 정보 조회"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "오늘의 기분 조회 성공 응답입니다.", useReturnTypeSchema = true
+    )
+    @GetMapping("/{moodDate}")
+    public ResponseEntity<ApiSuccessResponse<MoodResponseDto>> get(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("moodDate") LocalDate localDate) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(SUCCESS, moodService.get(userDetails, localDate)));
+    }
+}

--- a/src/main/java/com/remind/api/mood/dto/ActivityListDto.java
+++ b/src/main/java/com/remind/api/mood/dto/ActivityListDto.java
@@ -1,4 +1,4 @@
-package com.remind.api.mood.dto.response;
+package com.remind.api.mood.dto;
 
 import com.remind.core.domain.mood.Activity;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/remind/api/mood/dto/ActivityListDto.java
+++ b/src/main/java/com/remind/api/mood/dto/ActivityListDto.java
@@ -6,13 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "추가한 활동 리스트 model")
 public record ActivityListDto(
+        @Schema(description = "활동 ID")
+        Long activityId,
         @Schema(description = "활동명")
         String name,
         @Schema(description = "아이콘 이미지")
         String iconImage
 ) {
 
-    public static ActivityListDto fromEntity(Activity activity){
-        return new ActivityListDto(activity.getActivityName(),activity.getActivityIcon());
+    public static ActivityListDto fromEntity(Activity activity) {
+        return new ActivityListDto(activity.getId(), activity.getActivityName(), activity.getActivityIcon());
     }
 }

--- a/src/main/java/com/remind/api/mood/dto/MoodChartDto.java
+++ b/src/main/java/com/remind/api/mood/dto/MoodChartDto.java
@@ -1,0 +1,41 @@
+package com.remind.api.mood.dto;
+
+import com.remind.core.domain.mood.enums.FeelingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoodChartDto {
+
+    @Schema(description = "날짜")
+    private LocalDate localDate;
+    @Schema(description = "해당 날짜의 기분")
+    private FeelingType feeling;
+
+    @Getter
+    @Schema(description = "무드 차트 데이터")
+    public static class MoodChartResponseDto {
+
+        @Schema(description = "날짜")
+        private final Integer day;
+        @Schema(description = "해당 날짜의 기분")
+        private final String feeling;
+        @Schema(description = "기분에 대한 점수")
+        private final Integer score;
+
+        private MoodChartResponseDto(FeelingType feelingType, Integer day) {
+            this.day = day;
+            this.feeling = feelingType.getFeeling();
+            this.score = feelingType.getScore();
+        }
+    }
+
+    public MoodChartResponseDto toResponseDto(FeelingType feelingType, Integer day) {
+        return new MoodChartResponseDto(feelingType, day);
+    }
+}

--- a/src/main/java/com/remind/api/mood/dto/MoodChartDto.java
+++ b/src/main/java/com/remind/api/mood/dto/MoodChartDto.java
@@ -22,20 +22,20 @@ public class MoodChartDto {
     public static class MoodChartResponseDto {
 
         @Schema(description = "날짜")
-        private final Integer day;
+        private final LocalDate localDate;
         @Schema(description = "해당 날짜의 기분")
         private final String feeling;
         @Schema(description = "기분에 대한 점수")
         private final Integer score;
 
-        private MoodChartResponseDto(FeelingType feelingType, Integer day) {
-            this.day = day;
+        private MoodChartResponseDto(FeelingType feelingType, LocalDate localDate) {
+            this.localDate = localDate;
             this.feeling = feelingType.getFeeling();
             this.score = feelingType.getScore();
         }
     }
 
-    public MoodChartResponseDto toResponseDto(FeelingType feelingType, Integer day) {
-        return new MoodChartResponseDto(feelingType, day);
+    public MoodChartResponseDto toResponseDto(FeelingType feelingType, LocalDate localDate) {
+        return new MoodChartResponseDto(feelingType, localDate);
     }
 }

--- a/src/main/java/com/remind/api/mood/dto/request/ActivitySaveRequestDto.java
+++ b/src/main/java/com/remind/api/mood/dto/request/ActivitySaveRequestDto.java
@@ -1,0 +1,12 @@
+package com.remind.api.mood.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "활동 추가 요청 model")
+public record ActivitySaveRequestDto(
+        @Schema(description = "활동명")
+        String name,
+        @Schema(description = "아이콘 이미지")
+        String iconImage
+) {
+}

--- a/src/main/java/com/remind/api/mood/dto/request/MoodActivityRequestDto.java
+++ b/src/main/java/com/remind/api/mood/dto/request/MoodActivityRequestDto.java
@@ -1,0 +1,19 @@
+package com.remind.api.mood.dto.request;
+
+import com.remind.core.domain.mood.enums.FeelingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "오늘의 기분 속 활동 정보")
+public record MoodActivityRequestDto(
+        @Schema(description = "활동 ID")
+        @NotNull(message = "활동 ID는 필수 값입니다.")
+        Long activityId,
+        @Schema(description = "활동을 하며 느낀 기분 VERY_GOOD(매우 좋음), GOOD(좋음), NORMAL(보통), BAD(나쁨),TERRIBLE(끔찍함)")
+        @NotBlank(message = "느낀 기분은 필수 입니다.")
+        FeelingType feelingType,
+        @Schema(description = "활동을 하며 느낀 것 메모")
+        String detail
+) {
+}

--- a/src/main/java/com/remind/api/mood/dto/request/MoodSaveRequestDto.java
+++ b/src/main/java/com/remind/api/mood/dto/request/MoodSaveRequestDto.java
@@ -1,0 +1,25 @@
+package com.remind.api.mood.dto.request;
+
+import com.remind.core.domain.mood.enums.FeelingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Schema(description = "오늘의 기분 생성 요청 model")
+public record MoodSaveRequestDto(
+        @Schema(description = "생성 날짜")
+        @NotNull(message = "생성 날짜는 필수 값입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate localDate,
+        @Schema(description = "오늘의 기분")
+        FeelingType feelingType,
+        @Schema(description = "오늘의 하루 활동들")
+        @Nullable
+        List<MoodActivityRequestDto> moodActivities,
+        @Schema(description = "오늘 하루 감사한 점 3가지")
+        String detail
+) {
+}

--- a/src/main/java/com/remind/api/mood/dto/response/ActivityListDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/ActivityListDto.java
@@ -1,0 +1,18 @@
+package com.remind.api.mood.dto.response;
+
+import com.remind.core.domain.mood.Activity;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+@Schema(description = "추가한 활동 리스트 model")
+public record ActivityListDto(
+        @Schema(description = "활동명")
+        String name,
+        @Schema(description = "아이콘 이미지")
+        String iconImage
+) {
+
+    public static ActivityListDto fromEntity(Activity activity){
+        return new ActivityListDto(activity.getActivityName(),activity.getActivityIcon());
+    }
+}

--- a/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
@@ -1,5 +1,6 @@
 package com.remind.api.mood.dto.response;
 
+import com.remind.api.mood.dto.ActivityListDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 @Schema(description = "추가한 활동 목록")

--- a/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
@@ -1,10 +1,11 @@
 package com.remind.api.mood.dto.response;
 
-import com.remind.core.domain.mood.Activity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-
+@Schema(description = "추가한 활동 목록")
 public record ActivityListResponseDto(
-        List<Activity> activities
+        @Schema(description = "환자가 추가한 활동들 목록")
+        List<ActivityListDto> activities
 ) {
 
 }

--- a/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/ActivityListResponseDto.java
@@ -1,0 +1,10 @@
+package com.remind.api.mood.dto.response;
+
+import com.remind.core.domain.mood.Activity;
+import java.util.List;
+
+public record ActivityListResponseDto(
+        List<Activity> activities
+) {
+
+}

--- a/src/main/java/com/remind/api/mood/dto/response/ModelActivityResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/ModelActivityResponseDto.java
@@ -1,0 +1,18 @@
+package com.remind.api.mood.dto.response;
+
+import com.remind.core.domain.mood.enums.FeelingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "오늘의 활동 model")
+public record ModelActivityResponseDto(
+        @Schema(description = "활동 이름")
+        String name,
+        @Schema(description = "활동 아이콘 이미지")
+        String iconImg,
+        @Schema(description = "활동에서 느낀 기분")
+        FeelingType feelingType,
+        @Schema(description = "활동 느낀 점")
+        String detail
+
+) {
+}

--- a/src/main/java/com/remind/api/mood/dto/response/MoodChartPagingResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/MoodChartPagingResponseDto.java
@@ -1,0 +1,12 @@
+package com.remind.api.mood.dto.response;
+
+import com.remind.api.mood.dto.MoodChartDto.MoodChartResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "무드 차트 한 달 응답 데이터 model")
+public record MoodChartPagingResponseDto(
+        @Schema(description = "한 달 기분 정보 리스트")
+        List<MoodChartResponseDto> moodChartDtos
+) {
+}

--- a/src/main/java/com/remind/api/mood/dto/response/MoodChartPagingResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/MoodChartPagingResponseDto.java
@@ -7,6 +7,8 @@ import java.util.List;
 @Schema(description = "무드 차트 한 달 응답 데이터 model")
 public record MoodChartPagingResponseDto(
         @Schema(description = "한 달 기분 정보 리스트")
-        List<MoodChartResponseDto> moodChartDtos
+        List<MoodChartResponseDto> moodChartDtos,
+        @Schema(description = "다음 페이지 존재 여부")
+        Boolean hasNext
 ) {
 }

--- a/src/main/java/com/remind/api/mood/dto/response/MoodResponseDto.java
+++ b/src/main/java/com/remind/api/mood/dto/response/MoodResponseDto.java
@@ -1,0 +1,17 @@
+package com.remind.api.mood.dto.response;
+
+import com.remind.core.domain.mood.enums.FeelingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "특정 날짜 기분 조회 응답 model")
+public record MoodResponseDto(
+        @Schema(description = "오늘의 기분 종류 VERY_GOOD(매우 좋음), GOOD(좋음), NORMAL(보통), BAD(나쁨),TERRIBLE(끔찍함)")
+        FeelingType feelingType,
+        @Schema(description = "오늘의 하루 감사한 점")
+        String moodDetail,
+        @Schema(description = "오늘의 하루 활동들")
+        List<ModelActivityResponseDto> activities
+
+) {
+}

--- a/src/main/java/com/remind/api/mood/exception/MoodExceptionHandler.java
+++ b/src/main/java/com/remind/api/mood/exception/MoodExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.remind.api.mood.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import com.remind.core.domain.common.exception.ActivityException;
+import com.remind.core.domain.common.exception.MemberException;
+import com.remind.core.domain.common.exception.MoodException;
+import com.remind.core.domain.common.response.ErrorResponse;
+import com.remind.core.domain.enums.ActivityErrorCode;
+import com.remind.core.domain.enums.MemberErrorCode;
+import com.remind.core.domain.enums.MoodErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class MoodExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) {
+        log.error(">>>>> Internal Server Error : {}", ex);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ErrorResponse> handleMemberException(MemberException ex) {
+        log.error(">>>>> Member Error : {}", ex);
+        MemberErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ErrorResponse.builder()
+                .errorCode(errorCode.getErrorCode())
+                .errorMessage(errorCode.getErrorMessage())
+                .build());
+    }
+
+    @ExceptionHandler(ActivityException.class)
+    public ResponseEntity<ErrorResponse> handleActivityException(ActivityException ex) {
+        log.error(">>>>> Activity Error : {}", ex);
+        ActivityErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ErrorResponse.builder()
+                .errorCode(errorCode.getErrorCode())
+                .errorMessage(errorCode.getErrorMessage())
+                .build());
+    }
+
+    @ExceptionHandler(MoodException.class)
+    public ResponseEntity<ErrorResponse> handleMoodException(MoodException ex) {
+        log.error(">>>>> Mood Error : {}", ex);
+        MoodErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ErrorResponse.builder()
+                .errorCode(errorCode.getErrorCode())
+                .errorMessage(errorCode.getErrorMessage())
+                .build());
+    }
+}

--- a/src/main/java/com/remind/api/mood/repository/DateMoodActivityRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/DateMoodActivityRepository.java
@@ -1,0 +1,20 @@
+package com.remind.api.mood.repository;
+
+import com.remind.api.mood.dto.response.ModelActivityResponseDto;
+import com.remind.core.domain.mood.repository.MoodActivityRepository;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DateMoodActivityRepository extends MoodActivityRepository {
+    /**
+     * 특정 날짜의 오늘의 기분에 포함된 활동들에 대한 정보를 추출한다.
+     */
+    @Query("select new com.remind.api.mood.dto.response.ModelActivityResponseDto"
+            + "(activity.activityName,activity.activityIcon,modelActivity.feelingType,modelActivity.moodActivityDetails) "
+            + "from MoodActivity modelActivity "
+            + "left join Activity activity on modelActivity.activity.id = activity.id "
+            + "where modelActivity.mood.id = :moodId")
+    List<ModelActivityResponseDto> getModelActivities(@Param("moodId") Long moodId);
+
+}

--- a/src/main/java/com/remind/api/mood/repository/MoodChartPagingRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/MoodChartPagingRepository.java
@@ -2,21 +2,23 @@ package com.remind.api.mood.repository;
 
 import com.remind.api.mood.dto.MoodChartDto;
 import com.remind.core.domain.mood.repository.MoodRepository;
-import java.util.List;
+import java.time.LocalDate;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MoodChartPagingRepository extends MoodRepository {
 
     /**
-     * 환자의 특정 년도, 월의 무드 데이터를 가져오고 오름차순으로 정렬한다.
+     * 환자의 특정 년도, 월의 cursor 기반 페이지네이션
      */
     @Query("select new com.remind.api.mood.dto.MoodChartDto"
             + "(mood.moodDate,mood.feelingType) "
             + "from Mood mood "
-            + "where mood.patient.id = :memberId and year(mood.moodDate) =:yearCursor and month(mood.moodDate) = :monthCursor "
+            + "where mood.patient.id = :memberId and mood.moodDate > :moodDate "
             + "order by mood.moodDate asc")
-    List<MoodChartDto> getMoodChartPaging(@Param("memberId") Long memberId,
-                                          @Param("yearCursor") Integer yearCursor,
-                                          @Param("monthCursor") Integer monthCursor);
+    Slice<MoodChartDto> getMoodChartPaging2(@Param("memberId") Long memberId,
+                                            @Param("moodDate") LocalDate moodDate,
+                                            Pageable pageable);
 }

--- a/src/main/java/com/remind/api/mood/repository/MoodChartPagingRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/MoodChartPagingRepository.java
@@ -1,0 +1,22 @@
+package com.remind.api.mood.repository;
+
+import com.remind.api.mood.dto.MoodChartDto;
+import com.remind.core.domain.mood.repository.MoodRepository;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MoodChartPagingRepository extends MoodRepository {
+
+    /**
+     * 환자의 특정 년도, 월의 무드 데이터를 가져오고 오름차순으로 정렬한다.
+     */
+    @Query("select new com.remind.api.mood.dto.MoodChartDto"
+            + "(mood.moodDate,mood.feelingType) "
+            + "from Mood mood "
+            + "where mood.patient.id = :memberId and year(mood.moodDate) =:yearCursor and month(mood.moodDate) = :monthCursor "
+            + "order by mood.moodDate asc")
+    List<MoodChartDto> getMoodChartPaging(@Param("memberId") Long memberId,
+                                          @Param("yearCursor") Integer yearCursor,
+                                          @Param("monthCursor") Integer monthCursor);
+}

--- a/src/main/java/com/remind/api/mood/service/ActivityService.java
+++ b/src/main/java/com/remind/api/mood/service/ActivityService.java
@@ -1,0 +1,63 @@
+package com.remind.api.mood.service;
+
+import static com.remind.core.domain.enums.MemberErrorCode.*;
+
+import com.remind.api.mood.dto.request.ActivitySaveRequestDto;
+import com.remind.api.mood.dto.response.ActivityListResponseDto;
+import com.remind.core.domain.common.exception.MemberException;
+import com.remind.core.domain.member.Member;
+import com.remind.core.domain.member.enums.RolesType;
+import com.remind.core.domain.member.repository.MemberRepository;
+import com.remind.core.domain.mood.Activity;
+import com.remind.core.domain.mood.repository.ActivityRepository;
+import com.remind.core.security.dto.UserDetailsImpl;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityService {
+
+    private final ActivityRepository activityRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long save(UserDetailsImpl userDetails, ActivitySaveRequestDto dto) {
+        // 환자만 접근 가능
+        if (!validateUserRole(userDetails)) {
+            throw new MemberException(MEMBER_UNAUTHORIZED);
+        }
+
+        Member member = memberRepository.findById(userDetails.getMemberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        Activity activity = Activity.builder()
+                .member(member)
+                .activityName(dto.name())
+                .activityIcon(dto.iconImage())
+                .build();
+
+        activityRepository.save(activity);
+
+        return activity.getId();
+    }
+
+
+    @Transactional(readOnly = true)
+    public ActivityListResponseDto getActivityList(UserDetailsImpl userDetails) {
+        // 환자만 접근 가능
+        if (!validateUserRole(userDetails)) {
+            throw new MemberException(MEMBER_UNAUTHORIZED);
+        }
+
+        List<Activity> activities = activityRepository.findActivitiesByMemberId(userDetails.getMemberId());
+//        List<Activity> activities = activityRepository.findActivitiesByMemberId(1L);
+        return new ActivityListResponseDto(activities);
+    }
+
+    private Boolean validateUserRole(UserDetailsImpl userDetails) {
+        return RolesType.validateUserRole(userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/remind/api/mood/service/ActivityService.java
+++ b/src/main/java/com/remind/api/mood/service/ActivityService.java
@@ -3,6 +3,7 @@ package com.remind.api.mood.service;
 import static com.remind.core.domain.enums.MemberErrorCode.*;
 
 import com.remind.api.mood.dto.request.ActivitySaveRequestDto;
+import com.remind.api.mood.dto.response.ActivityListDto;
 import com.remind.api.mood.dto.response.ActivityListResponseDto;
 import com.remind.core.domain.common.exception.MemberException;
 import com.remind.core.domain.member.Member;
@@ -12,6 +13,7 @@ import com.remind.core.domain.mood.Activity;
 import com.remind.core.domain.mood.repository.ActivityRepository;
 import com.remind.core.security.dto.UserDetailsImpl;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +25,9 @@ public class ActivityService {
     private final ActivityRepository activityRepository;
     private final MemberRepository memberRepository;
 
+    /**
+     * 활동 추가
+     */
     @Transactional
     public Long save(UserDetailsImpl userDetails, ActivitySaveRequestDto dto) {
         // 환자만 접근 가능
@@ -44,7 +49,9 @@ public class ActivityService {
         return activity.getId();
     }
 
-
+    /**
+     * 추가한 활동 리스트 조회
+     */
     @Transactional(readOnly = true)
     public ActivityListResponseDto getActivityList(UserDetailsImpl userDetails) {
         // 환자만 접근 가능
@@ -52,8 +59,11 @@ public class ActivityService {
             throw new MemberException(MEMBER_UNAUTHORIZED);
         }
 
-        List<Activity> activities = activityRepository.findActivitiesByMemberId(userDetails.getMemberId());
-//        List<Activity> activities = activityRepository.findActivitiesByMemberId(1L);
+        List<ActivityListDto> activities = activityRepository.findActivitiesByMemberId(userDetails.getMemberId())
+                .stream()
+                .map(ActivityListDto::fromEntity)
+                .collect(Collectors.toList());
+
         return new ActivityListResponseDto(activities);
     }
 

--- a/src/main/java/com/remind/api/mood/service/ActivityService.java
+++ b/src/main/java/com/remind/api/mood/service/ActivityService.java
@@ -3,7 +3,7 @@ package com.remind.api.mood.service;
 import static com.remind.core.domain.enums.MemberErrorCode.*;
 
 import com.remind.api.mood.dto.request.ActivitySaveRequestDto;
-import com.remind.api.mood.dto.response.ActivityListDto;
+import com.remind.api.mood.dto.ActivityListDto;
 import com.remind.api.mood.dto.response.ActivityListResponseDto;
 import com.remind.core.domain.common.exception.MemberException;
 import com.remind.core.domain.member.Member;

--- a/src/main/java/com/remind/api/mood/service/MoodChartService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartService.java
@@ -33,9 +33,6 @@ public class MoodChartService {
         Slice<MoodChartDto> moodChartDtos = moodChartPagingRepository.getMoodChartPaging2(userDetails.getMemberId(),
                 LocalDate.of(year, month, day), Pageable.ofSize(size));
 
-        if (!moodChartDtos.hasContent()) {
-            throw new MoodException(MOOD_CHART_NOT_FOUND);
-        }
         // 다음 페이지 존재 여부
         if (moodChartDtos.hasNext()) {
             hasNext = true;

--- a/src/main/java/com/remind/api/mood/service/MoodChartService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartService.java
@@ -8,9 +8,12 @@ import com.remind.api.mood.dto.response.MoodChartPagingResponseDto;
 import com.remind.api.mood.repository.MoodChartPagingRepository;
 import com.remind.core.domain.common.exception.MoodException;
 import com.remind.core.security.dto.UserDetailsImpl;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,19 +24,25 @@ public class MoodChartService {
     private final MoodChartPagingRepository moodChartPagingRepository;
 
     @Transactional(readOnly = true)
-    public MoodChartPagingResponseDto getMoodChart(UserDetailsImpl userDetails, Integer year, Integer month) {
+    public MoodChartPagingResponseDto getMoodChart(UserDetailsImpl userDetails, Integer year, Integer month,
+                                                   Integer day, Integer size) {
 
         List<MoodChartResponseDto> response = new ArrayList<>();
-        List<MoodChartDto> moodChartDtos = moodChartPagingRepository.getMoodChartPaging(userDetails.getMemberId(), year,
-                month);
+        boolean hasNext = false;
+        // 요청한 정보에 대해 커서 기반 pagination
+        Slice<MoodChartDto> moodChartDtos = moodChartPagingRepository.getMoodChartPaging2(userDetails.getMemberId(),
+                LocalDate.of(year, month, day), Pageable.ofSize(size));
 
-        if (moodChartDtos.isEmpty()) {
+        if (!moodChartDtos.hasContent()) {
             throw new MoodException(MOOD_CHART_NOT_FOUND);
         }
-
-        moodChartDtos.forEach(moodChart -> {
-            response.add(moodChart.toResponseDto(moodChart.getFeeling(), moodChart.getLocalDate().getDayOfMonth()));
+        // 다음 페이지 존재 여부
+        if (moodChartDtos.hasNext()) {
+            hasNext = true;
+        }
+        moodChartDtos.getContent().forEach(moodChart -> {
+            response.add(moodChart.toResponseDto(moodChart.getFeeling(), moodChart.getLocalDate()));
         });
-        return new MoodChartPagingResponseDto(response);
+        return new MoodChartPagingResponseDto(response, hasNext);
     }
 }

--- a/src/main/java/com/remind/api/mood/service/MoodChartService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartService.java
@@ -1,0 +1,39 @@
+package com.remind.api.mood.service;
+
+import static com.remind.core.domain.enums.MoodErrorCode.*;
+
+import com.remind.api.mood.dto.MoodChartDto;
+import com.remind.api.mood.dto.MoodChartDto.MoodChartResponseDto;
+import com.remind.api.mood.dto.response.MoodChartPagingResponseDto;
+import com.remind.api.mood.repository.MoodChartPagingRepository;
+import com.remind.core.domain.common.exception.MoodException;
+import com.remind.core.security.dto.UserDetailsImpl;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MoodChartService {
+
+    private final MoodChartPagingRepository moodChartPagingRepository;
+
+    @Transactional(readOnly = true)
+    public MoodChartPagingResponseDto getMoodChart(UserDetailsImpl userDetails, Integer year, Integer month) {
+
+        List<MoodChartResponseDto> response = new ArrayList<>();
+        List<MoodChartDto> moodChartDtos = moodChartPagingRepository.getMoodChartPaging(userDetails.getMemberId(), year,
+                month);
+
+        if (moodChartDtos.isEmpty()) {
+            throw new MoodException(MOOD_CHART_NOT_FOUND);
+        }
+
+        moodChartDtos.forEach(moodChart -> {
+            response.add(moodChart.toResponseDto(moodChart.getFeeling(), moodChart.getLocalDate().getDayOfMonth()));
+        });
+        return new MoodChartPagingResponseDto(response);
+    }
+}

--- a/src/main/java/com/remind/api/mood/service/MoodService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodService.java
@@ -1,0 +1,100 @@
+package com.remind.api.mood.service;
+
+import static com.remind.core.domain.enums.ActivityErrorCode.*;
+import static com.remind.core.domain.enums.MemberErrorCode.*;
+import static com.remind.core.domain.enums.MoodErrorCode.MOOD_ALREADY_EXIST;
+import static com.remind.core.domain.enums.MoodErrorCode.MOOD_NOT_FOUND;
+
+import com.remind.api.mood.dto.request.MoodSaveRequestDto;
+import com.remind.api.mood.dto.response.ModelActivityResponseDto;
+import com.remind.api.mood.dto.response.MoodResponseDto;
+import com.remind.core.domain.common.exception.ActivityException;
+import com.remind.core.domain.common.exception.MemberException;
+import com.remind.core.domain.common.exception.MoodException;
+import com.remind.core.domain.member.Member;
+import com.remind.core.domain.member.repository.MemberRepository;
+import com.remind.core.domain.mood.Activity;
+import com.remind.core.domain.mood.Mood;
+import com.remind.core.domain.mood.MoodActivity;
+import com.remind.core.domain.mood.repository.ActivityRepository;
+import com.remind.core.domain.mood.repository.MoodActivityRepository;
+import com.remind.core.domain.mood.repository.MoodRepository;
+import com.remind.core.security.dto.UserDetailsImpl;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MoodService {
+
+    private final MoodActivityRepository moodActivityRepository;
+    private final MoodRepository moodRepository;
+    private final MemberRepository memberRepository;
+    private final ActivityRepository activityRepository;
+
+    /**
+     * 오늘의 기분 기록
+     */
+    @Transactional
+    public Long create(UserDetailsImpl userDetails, MoodSaveRequestDto dto) {
+
+        Member member = memberRepository.findById(userDetails.getMemberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        // 동일 날짜에 이미 오늘의 기분이 존재하면 예외 처리
+        moodRepository.findMoodByPatientAndMoodDate(member.getId(), dto.localDate())
+                .stream().findAny().ifPresent((mood) -> {
+                    throw new MoodException(MOOD_ALREADY_EXIST);
+                });
+
+        Mood mood = Mood.builder()
+                .patient(member)
+                .feelingType(dto.feelingType())
+                .moodDetail(dto.detail())
+                .moodDate(dto.localDate())
+                .build();
+
+        moodRepository.save(mood);
+
+        /*
+         * 오늘의 활동이 존재하면, 각각의 활동에 대해 MoodActivity를 생성한다.
+         */
+        if (dto.moodActivities() != null) {
+            dto.moodActivities().forEach(model -> {
+
+                Activity activity = activityRepository.findById(model.activityId())
+                        .orElseThrow(() -> new ActivityException(ACTIVITY_NOT_FOUND));
+
+                MoodActivity moodActivity = MoodActivity.builder()
+                        .mood(mood)
+                        .activity(activity)
+                        .moodActivityDetails(model.detail())
+                        .feelingType(model.feelingType())
+                        .build();
+
+                moodActivityRepository.save(moodActivity);
+            });
+        }
+
+        return mood.getId();
+    }
+
+    /**
+     * 특정 날짜의 오늘의 기분 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public MoodResponseDto get(UserDetailsImpl userDetails, LocalDate localDate) {
+
+        Mood mood = moodRepository.findMoodByPatientAndMoodDate(userDetails.getMemberId(), localDate)
+                .orElseThrow(() -> new MoodException(MOOD_NOT_FOUND));
+
+        List<ModelActivityResponseDto> modelActivities = moodActivityRepository.getModelActivities(mood.getId());
+
+        return new MoodResponseDto(mood.getFeelingType(), mood.getMoodDetail(), modelActivities);
+    }
+}

--- a/src/main/java/com/remind/api/mood/service/MoodService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodService.java
@@ -8,6 +8,7 @@ import static com.remind.core.domain.enums.MoodErrorCode.MOOD_NOT_FOUND;
 import com.remind.api.mood.dto.request.MoodSaveRequestDto;
 import com.remind.api.mood.dto.response.ModelActivityResponseDto;
 import com.remind.api.mood.dto.response.MoodResponseDto;
+import com.remind.api.mood.repository.DateMoodActivityRepository;
 import com.remind.core.domain.common.exception.ActivityException;
 import com.remind.core.domain.common.exception.MemberException;
 import com.remind.core.domain.common.exception.MoodException;
@@ -36,6 +37,7 @@ public class MoodService {
     private final MoodRepository moodRepository;
     private final MemberRepository memberRepository;
     private final ActivityRepository activityRepository;
+    private final DateMoodActivityRepository dateMoodActivityRepository;
 
     /**
      * 오늘의 기분 기록
@@ -93,7 +95,7 @@ public class MoodService {
         Mood mood = moodRepository.findMoodByPatientAndMoodDate(userDetails.getMemberId(), localDate)
                 .orElseThrow(() -> new MoodException(MOOD_NOT_FOUND));
 
-        List<ModelActivityResponseDto> modelActivities = moodActivityRepository.getModelActivities(mood.getId());
+        List<ModelActivityResponseDto> modelActivities = dateMoodActivityRepository.getModelActivities(mood.getId());
 
         return new MoodResponseDto(mood.getFeelingType(), mood.getMoodDetail(), modelActivities);
     }

--- a/src/main/java/com/remind/core/domain/common/exception/ActivityException.java
+++ b/src/main/java/com/remind/core/domain/common/exception/ActivityException.java
@@ -1,0 +1,15 @@
+package com.remind.core.domain.common.exception;
+
+import com.remind.core.domain.enums.ActivityErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ActivityException extends RuntimeException {
+
+    private ActivityErrorCode errorCode;
+
+    public ActivityException(ActivityErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/remind/core/domain/common/exception/MemberException.java
+++ b/src/main/java/com/remind/core/domain/common/exception/MemberException.java
@@ -1,4 +1,4 @@
-package com.remind.api.member.exception;
+package com.remind.core.domain.common.exception;
 
 import com.remind.core.domain.enums.MemberErrorCode;
 import lombok.Getter;

--- a/src/main/java/com/remind/core/domain/common/exception/MoodException.java
+++ b/src/main/java/com/remind/core/domain/common/exception/MoodException.java
@@ -1,0 +1,16 @@
+package com.remind.core.domain.common.exception;
+
+
+import com.remind.core.domain.enums.MoodErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MoodException extends RuntimeException {
+
+    private MoodErrorCode errorCode;
+
+    public MoodException(MoodErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/remind/core/domain/enums/ActivityErrorCode.java
+++ b/src/main/java/com/remind/core/domain/enums/ActivityErrorCode.java
@@ -1,0 +1,26 @@
+package com.remind.core.domain.enums;
+
+import com.remind.core.domain.common.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ActivityErrorCode implements BaseErrorCode {
+
+    ACTIVITY_NOT_FOUND(404, "일치하는 activity가 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    ActivityErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return null;
+    }
+}

--- a/src/main/java/com/remind/core/domain/enums/MemberErrorCode.java
+++ b/src/main/java/com/remind/core/domain/enums/MemberErrorCode.java
@@ -11,7 +11,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     REFRESH_TOKEN_NOT_MATCH(404, "저장된 refresh token 값과 일치하지 않습니다.", HttpStatus.NOT_FOUND),
     MEMBER_NOT_FOUND(404, "일치하는 member가 없습니다.", HttpStatus.NOT_FOUND),
     AUTH_ID_NOT_FOUND(404, "kakao auth id와 일치하는 member가 없습니다.", HttpStatus.NOT_FOUND),
-    ;
+    MEMBER_UNAUTHORIZED(401, "환자만 접근 가능합니다.", HttpStatus.UNAUTHORIZED);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/remind/core/domain/enums/MoodErrorCode.java
+++ b/src/main/java/com/remind/core/domain/enums/MoodErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum MoodErrorCode implements BaseErrorCode {
 
     MOOD_ALREADY_EXIST(400, "해당 날짜의 오늘의 기분이 이미 존재합니다.", HttpStatus.BAD_REQUEST),
-    MOOD_NOT_FOUND(404, "해당 날짜에 존재하는 오늘의 기분이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+    MOOD_NOT_FOUND(404, "해당 날짜에 존재하는 오늘의 기분이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    MOOD_CHART_NOT_FOUND(404, "해당 년,월에 존재하는 무드 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/remind/core/domain/enums/MoodErrorCode.java
+++ b/src/main/java/com/remind/core/domain/enums/MoodErrorCode.java
@@ -1,0 +1,27 @@
+package com.remind.core.domain.enums;
+
+import com.remind.core.domain.common.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MoodErrorCode implements BaseErrorCode {
+
+    MOOD_ALREADY_EXIST(400, "해당 날짜의 오늘의 기분이 이미 존재합니다.", HttpStatus.BAD_REQUEST),
+    MOOD_NOT_FOUND(404, "해당 날짜에 존재하는 오늘의 기분이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    MoodErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return null;
+    }
+}

--- a/src/main/java/com/remind/core/domain/member/enums/RolesType.java
+++ b/src/main/java/com/remind/core/domain/member/enums/RolesType.java
@@ -1,12 +1,17 @@
 package com.remind.core.domain.member.enums;
 
+import java.util.Collection;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
 
 @Getter
 public enum RolesType {
 
     ROLE_USER,  // 일반 회원(환자)
     ROLE_DOCTOR, // 의사
-    ROLE_CENTER  // 센터 관리자
+    ROLE_CENTER;  // 센터 관리자
 
+    public static Boolean validateUserRole(Collection<? extends GrantedAuthority> roles) {
+        return roles.stream().anyMatch(role -> role.getAuthority().equals(ROLE_USER.name()));
+    }
 }

--- a/src/main/java/com/remind/core/domain/mood/Activity.java
+++ b/src/main/java/com/remind/core/domain/mood/Activity.java
@@ -1,0 +1,41 @@
+package com.remind.core.domain.mood;
+
+import com.remind.core.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Activity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mood_activity_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "patient_id", nullable = false)
+    private Member member;
+
+    @Column(name = "activity_name", nullable = false)
+    private String activityName;
+
+    @Column(name = "activity_icon", nullable = false)
+    private String activityIcon;
+
+}

--- a/src/main/java/com/remind/core/domain/mood/Activity.java
+++ b/src/main/java/com/remind/core/domain/mood/Activity.java
@@ -25,7 +25,6 @@ public class Activity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mood_activity_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/remind/core/domain/mood/Mood.java
+++ b/src/main/java/com/remind/core/domain/mood/Mood.java
@@ -12,7 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +28,6 @@ public class Mood {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mood_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -43,5 +42,5 @@ public class Mood {
     private String moodDetail;
 
     @Column(name = "mood_date", nullable = false)
-    private LocalDateTime moodDate;
+    private LocalDate moodDate;
 }

--- a/src/main/java/com/remind/core/domain/mood/Mood.java
+++ b/src/main/java/com/remind/core/domain/mood/Mood.java
@@ -1,0 +1,47 @@
+package com.remind.core.domain.mood;
+
+import com.remind.core.domain.member.Member;
+import com.remind.core.domain.mood.enums.FeelingType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mood {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mood_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "patient_id", nullable = false)
+    private Member patient;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feeling_type", nullable = false)
+    private FeelingType feelingType;
+
+    @Column(name = "mood_detail", nullable = true)
+    private String moodDetail;
+
+    @Column(name = "mood_date", nullable = false)
+    private LocalDateTime moodDate;
+}

--- a/src/main/java/com/remind/core/domain/mood/MoodActivity.java
+++ b/src/main/java/com/remind/core/domain/mood/MoodActivity.java
@@ -1,0 +1,39 @@
+package com.remind.core.domain.mood;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoodActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mood_activity_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mood_id", nullable = false)
+    private Mood mood;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @Column(name = "mood_activity_detail", nullable = true)
+    private String moodActivityDetails;
+}

--- a/src/main/java/com/remind/core/domain/mood/MoodActivity.java
+++ b/src/main/java/com/remind/core/domain/mood/MoodActivity.java
@@ -1,7 +1,10 @@
 package com.remind.core.domain.mood;
 
+import com.remind.core.domain.mood.enums.FeelingType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,7 +26,6 @@ public class MoodActivity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mood_activity_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,4 +38,8 @@ public class MoodActivity {
 
     @Column(name = "mood_activity_detail", nullable = true)
     private String moodActivityDetails;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feeling_type", nullable = false)
+    private FeelingType feelingType;
 }

--- a/src/main/java/com/remind/core/domain/mood/enums/FeelingType.java
+++ b/src/main/java/com/remind/core/domain/mood/enums/FeelingType.java
@@ -1,9 +1,16 @@
 package com.remind.core.domain.mood.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum FeelingType {
-    VERY_GOOD, // 매우 좋음
-    GOOD, // 좋음
-    NORMAL, // 보통
-    BAD, // 나쁨
-    TERRIBLE // 끔찍함
+    VERY_GOOD("VERY_GOOD", 100), // 매우 좋음
+    GOOD("GOOD", 75), // 좋음
+    NORMAL("NORMAL", 50), // 보통
+    BAD("BAD", 25), // 나쁨
+    TERRIBLE("TERRIBLE", 0); // 끔찍함
+    final String feeling;
+    final int score;
 }

--- a/src/main/java/com/remind/core/domain/mood/enums/FeelingType.java
+++ b/src/main/java/com/remind/core/domain/mood/enums/FeelingType.java
@@ -1,0 +1,9 @@
+package com.remind.core.domain.mood.enums;
+
+public enum FeelingType {
+    VERY_GOOD, // 매우 좋음
+    GOOD, // 좋음
+    NORMAL, // 보통
+    BAD, // 나쁨
+    TERRIBLE // 끔찍함
+}

--- a/src/main/java/com/remind/core/domain/mood/repository/ActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/ActivityRepository.java
@@ -1,0 +1,15 @@
+package com.remind.core.domain.mood.repository;
+
+import com.remind.core.domain.mood.Activity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+    /**
+     * member id를 이용하여 해당 맴버가 추가한 활동을 조회하는 쿼리
+     */
+    @Query("select activity from Activity activity where activity.member.id = :memberId")
+    List<Activity> findActivitiesByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
@@ -1,21 +1,9 @@
 package com.remind.core.domain.mood.repository;
 
-import com.remind.api.mood.dto.response.ModelActivityResponseDto;
+
 import com.remind.core.domain.mood.MoodActivity;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MoodActivityRepository extends JpaRepository<MoodActivity, Long> {
 
-    /**
-     * 특정 날짜의 오늘의 기분에 포함된 활동들에 대한 정보를 추출한다.
-     */
-    @Query("select new com.remind.api.mood.dto.response.ModelActivityResponseDto"
-            + "(activity.activityName,activity.activityIcon,modelActivity.feelingType,modelActivity.moodActivityDetails) "
-            + "from MoodActivity modelActivity "
-            + "left join Activity activity on modelActivity.activity.id = activity.id "
-            + "where modelActivity.mood.id = :moodId")
-    List<ModelActivityResponseDto> getModelActivities(@Param("moodId") Long moodId);
 }

--- a/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
@@ -1,8 +1,21 @@
 package com.remind.core.domain.mood.repository;
 
+import com.remind.api.mood.dto.response.ModelActivityResponseDto;
 import com.remind.core.domain.mood.MoodActivity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MoodActivityRepository extends JpaRepository<MoodActivity, Long> {
 
+    /**
+     * 특정 날짜의 오늘의 기분에 포함된 활동들에 대한 정보를 추출한다.
+     */
+    @Query("select new com.remind.api.mood.dto.response.ModelActivityResponseDto"
+            + "(activity.activityName,activity.activityIcon,modelActivity.feelingType,modelActivity.moodActivityDetails) "
+            + "from MoodActivity modelActivity "
+            + "left join Activity activity on modelActivity.activity.id = activity.id "
+            + "where modelActivity.mood.id = :moodId")
+    List<ModelActivityResponseDto> getModelActivities(@Param("moodId") Long moodId);
 }

--- a/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/MoodActivityRepository.java
@@ -1,0 +1,8 @@
+package com.remind.core.domain.mood.repository;
+
+import com.remind.core.domain.mood.MoodActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoodActivityRepository extends JpaRepository<MoodActivity, Long> {
+
+}

--- a/src/main/java/com/remind/core/domain/mood/repository/MoodRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/MoodRepository.java
@@ -1,0 +1,15 @@
+package com.remind.core.domain.mood.repository;
+
+import com.remind.core.domain.mood.Mood;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MoodRepository extends JpaRepository<Mood, Long> {
+    @Query("select mood from Mood mood where mood.patient.id = :patientId and mood.moodDate = :moodDate")
+    Optional<Mood> findMoodByPatientAndMoodDate(@Param("patientId") Long patientId,
+                                                @Param("moodDate") LocalDate moodDate);
+
+}

--- a/src/main/java/com/remind/core/security/config/SecuirityConfig.java
+++ b/src/main/java/com/remind/core/security/config/SecuirityConfig.java
@@ -97,7 +97,8 @@ public class SecuirityConfig {
                 antMatcher(POST, "/activity"),
                 antMatcher(GET, "/activity"),
                 antMatcher(POST, "/mood"),
-                antMatcher(GET, "/mood")
+                antMatcher(GET, "/mood"),
+                antMatcher(GET, "/mood/chart")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/remind/core/security/config/SecuirityConfig.java
+++ b/src/main/java/com/remind/core/security/config/SecuirityConfig.java
@@ -94,6 +94,7 @@ public class SecuirityConfig {
     private RequestMatcher[] authorizeRequestMathcers() {
         List<RequestMatcher> requestMatchers = List.of(
                 antMatcher(POST, "/member/refresh")
+//                antMatcher(POST, "/activity")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/remind/core/security/config/SecuirityConfig.java
+++ b/src/main/java/com/remind/core/security/config/SecuirityConfig.java
@@ -93,8 +93,11 @@ public class SecuirityConfig {
      */
     private RequestMatcher[] authorizeRequestMathcers() {
         List<RequestMatcher> requestMatchers = List.of(
-                antMatcher(POST, "/member/refresh")
-//                antMatcher(POST, "/activity")
+                antMatcher(POST, "/member/refresh"),
+                antMatcher(POST, "/activity"),
+                antMatcher(GET, "/activity"),
+                antMatcher(POST, "/mood"),
+                antMatcher(GET, "/mood")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,13 +8,13 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: true
-  # data.sql 실행
+
     defer-datasource-initialization: true
   sql:
     init:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: true
+  # data.sql 실행
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
 
   ## redis 설정
   data:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+use
+remind;
+
+insert into member(id, auth_id, name, age, gender, email, phone_number, profile_image_url, is_onboarding_finished,
+                   registration_token, roles_type)
+VALUES (1, 1, '이상민', 27, 'men', '1234@gmail.com', '010-0000-0000', 'test-image-url', true, 'test-token', 'ROLE_USER');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,55 @@
+drop
+database IF EXISTS remind;
+
+create
+database IF NOT EXISTS remind;
+
+use
+remind;
+
+create table member
+(
+    id                     bigint not null auto_increment primary key,
+    auth_id                bigint,
+    name                   varchar(255),
+    age                    int,
+    gender                 varchar(5),
+    email                  varchar(30),
+    phone_number           varchar(20),
+    profile_image_url      varchar(50),
+    is_onboarding_finished boolean,
+    registration_token     varchar(255),
+    roles_type             varchar(255)
+);
+
+create table mood
+(
+    id           bigint not null auto_increment primary key,
+    patient_id   bigint not null,
+    feeling_type varchar(20),
+    mood_detail  text,
+    mood_date    date,
+    foreign key (patient_id) references member (id)
+);
+
+create table activity
+(
+    id            bigint not null auto_increment primary key,
+    patient_id    bigint not null,
+    activity_name varchar(20),
+    activity_icon varchar(255),
+    foreign key (patient_id) references member (id)
+);
+
+create table mood_activity
+(
+    id                   bigint not null auto_increment primary key,
+    mood_id              bigint not null,
+    activity_id          bigint not null,
+    mood_activity_detail text,
+    feeling_type         varchar(20),
+    foreign key (mood_id) references mood (id),
+    foreign key (activity_id) references activity (id)
+);
+
+create index idx_auth on member (auth_id, roles_type);


### PR DESCRIPTION
## 📝 작업 내용
 - 활동 추가 / 목록 조회 API 개발했습니다.
   -  mvp 단계에서 더미 데이터를 넣기로 하였는데 완성도 측면에서 너무 떨어질 것 같아 추가했습니다.
 - 오늘의 기분 API 추가 / 조회 API 개발했습니다. 
 - 추후 트리거를 작성하기 위해 ddl-auto : none으로 변경했습니다.
 
 - PR #26 를 해당 브랜치로 rebase merge하고 PR #21(Feature/12 오늘의 기분 API 추가 + 무트 차트 페이지네이션 추가)를 master 브랜치로 squash merge할 예정입니다!

## 💬 ETC.
**TODO**
- 오늘의 기분의 활동 데이터를 가지고 통계 테이블(기분 별 활동 차트) 에 insert 문을 날리는 트리거를 추가할 예정입니다.

## #️⃣ 연관된 이슈
close: #12 #22 
