### PR TITLE
feat : 도커 이미지 네트워크 모드 host 로 변경

### DIFF
--- a/.deploy/docker-compose.yml
+++ b/.deploy/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: always
     env_file:
       - .env
+    network_mode: host
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
```
version: '3.2'
services:
  remind:
    image: ${NCP_CONTAINER_REGISTRY_PUBLIC_ENDPOINT}/${NCP_CONTAINER_REGISTRY_IMAGE}
    container_name: ${NCP_CONTAINER_REGISTRY_IMAGE}
    restart: always
    env_file:
      - .env
    network_mode: host # 츄가!!!
    ports:
      - "8080:8080"
    environment:
      - TZ=Asia/Seoul
    volumes:
      - type: bind
        source: /root/.env
        target: /.env
```