### PR TITLE
feat(#30) : 로그인 후 온보딩 정보 등록 api 개발

### DIFF
--- a/src/main/java/com/remind/HealthTestController.java
+++ b/src/main/java/com/remind/HealthTestController.java
@@ -1,5 +1,7 @@
 package com.remind;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,9 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 //@Tag(name = "Health Check API", description = "Health Check API Controller입니다.")
 @RestController
 @RequestMapping("api/health")
-@Slf4j
+@SecurityRequirements(value = {})
+
 public class HealthTestController {
-//    @Operation(summary = "Health Check API", description = "Health Check Api입니다.")
+    @Operation(summary = "Health Check API", description = "Health Check Api입니다.")
     @GetMapping("")
     public String apiHealthTest() {
         return "remind! v9 - cicd찐최종;";

--- a/src/main/java/com/remind/api/member/controller/MemberController.java
+++ b/src/main/java/com/remind/api/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class MemberController {
             description = "kakao authorization code를 이용하여 발급받은 kakao accessToken을 사용하여 소셜 로그인 합니다."
     )
     @PostMapping("/login")
+    @SecurityRequirements(value = {})
     public ResponseEntity<ApiSuccessResponse<KakaoLoginResponse>> kakaoLogin(
             @RequestBody KakaoLoginRequest req
     ) {

--- a/src/main/java/com/remind/api/member/controller/MemberController.java
+++ b/src/main/java/com/remind/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.remind.api.member.controller;
 
 import com.remind.api.member.dto.request.KakaoLoginRequest;
+import com.remind.api.member.dto.request.OnboardingRequestDto;
 import com.remind.api.member.dto.response.KakaoLoginResponse;
 import com.remind.api.member.dto.request.RefreshTokenRequestDto;
 import com.remind.api.member.dto.response.TokenResponseDto;
@@ -8,6 +9,9 @@ import com.remind.api.member.service.MemberService;
 import com.remind.core.domain.common.response.ApiSuccessResponse;
 import com.remind.core.security.dto.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-
     @Operation(
             summary = "카카오 로그인 API",
             description = "kakao authorization code를 이용하여 발급받은 kakao accessToken을 사용하여 소셜 로그인 합니다."
@@ -39,6 +42,27 @@ public class MemberController {
         );
 
     }
+
+    @Operation(
+            summary = "로그인 후 온보딩 완료 API"
+    )
+    @ApiResponse(
+            responseCode = "201", description = "온보딩 정보 추가 성공 응답입니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(value = "{\"code\":201, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"userId\": 1, \"roles_type\": ROLE_USER}}")
+                    }
+            )
+    )
+    @PostMapping("/onboarding")
+    public ResponseEntity<ApiSuccessResponse<?>> onboarding(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody OnboardingRequestDto onboardingRequestDto
+    ) {
+        return ResponseEntity.ok(new ApiSuccessResponse<>(memberService.onboarding(userDetails, onboardingRequestDto)));
+    }
+
 
     @Operation(
             summary = "토큰 갱신 API",

--- a/src/main/java/com/remind/api/member/dto/request/OnboardingRequestDto.java
+++ b/src/main/java/com/remind/api/member/dto/request/OnboardingRequestDto.java
@@ -1,0 +1,22 @@
+package com.remind.api.member.dto.request;
+
+import com.remind.core.domain.member.enums.RolesType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "로그인이 끝난 후 온보딩에 사용하는 dto")
+public record OnboardingRequestDto(
+        @Schema(description = "역할 : ROLE_USER or ROLE_DOCTOR or ROLE_CENTER")
+        @NotNull(message = "역할은 필수 값입니다.")
+        RolesType rolesType,
+        @Schema(description = " ROLE_USER 인 경우, 보호자 전화번호")
+        String protectorPhoneNumber,
+        @Schema(description = " ROLE_CENTER인 경우, 시/도")
+        String city,
+        @Schema(description = " ROLE_CENTER인 경우, 군/구")
+        String district,
+        @Schema(description = " ROLE_CENTER인 경우, 센터명")
+        String centerName
+
+) {
+}

--- a/src/main/java/com/remind/api/member/dto/response/OnboardingResponseDto.java
+++ b/src/main/java/com/remind/api/member/dto/response/OnboardingResponseDto.java
@@ -1,0 +1,8 @@
+package com.remind.api.member.dto.response;
+
+import com.remind.core.domain.member.enums.RolesType;
+import lombok.Builder;
+
+@Builder
+public record OnboardingResponseDto(Long userId, RolesType rolesType) {
+}

--- a/src/main/java/com/remind/core/domain/member/Member.java
+++ b/src/main/java/com/remind/core/domain/member/Member.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -41,9 +42,43 @@ public class Member {
 
     private String profileImageUrl;
 
+    @ColumnDefault("false")
     private Boolean isOnboardingFinished;
 
     @Enumerated(value = EnumType.STRING)
     private RolesType rolesType;
 
+    // 환자를 위한 컬럼
+    private String protectorPhoneNumber;
+
+    // 센터를 위한 컬럼
+    private String city;
+
+    // 센터를 위한 컬럼
+    private String district;
+
+    // 센터를 위한 컬럼
+    private String centerName;
+
+    //온보딩 후 특정 컬럼 업데이트를 위한 메서드 - 환자용
+    public void updateRolesTypeForUser(RolesType rolesType,String protectorPhoneNumber) {
+        this.isOnboardingFinished = true;
+        this.rolesType = rolesType;
+        this.protectorPhoneNumber = protectorPhoneNumber;
+    }
+
+    //온보딩 후 특정 컬럼 업데이트를 위한 메서드 - 센터용
+    public void updateRolesTypeForCenter(RolesType rolesType,String city, String district, String centerName) {
+        this.isOnboardingFinished = true;
+        this.rolesType = rolesType;
+        this.city = city;
+        this.district = district;
+        this.centerName = centerName;
+    }
+
+    //온보딩 후 특정 컬럼 업데이트를 위한 메서드 - 의사용
+    public void updateRolesTypeForDoctor(RolesType rolesType) {
+        this.isOnboardingFinished = true;
+        this.rolesType = rolesType;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
 -  로그인 후, 온보딩 정보를 등록하는 api 개

## 💬 ETC.
 - `member` 내에 환자, 센터와 관련한 컬럼 추가
 - 온보딩 때 해당 컬럼을 update 하기 위한 메서드 세 개 추가

## #️⃣ 연관된 이슈
resolves:  #30 
