### PR TITLE
고정 활동 비즈니스 로직 수정 (테이블 설계 수정본 반영) 

### DIFF
--- a/src/main/java/com/remind/core/domain/common/enums/FixActivityErrorCode.java
+++ b/src/main/java/com/remind/core/domain/common/enums/FixActivityErrorCode.java
@@ -1,0 +1,27 @@
+package com.remind.core.domain.common.enums;
+
+import com.remind.core.domain.common.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum FixActivityErrorCode implements BaseErrorCode {
+    FIX_ACTIVITY_NOT_FOUND(500, "고정 활동을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+
+    FixActivityErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return null;
+    }
+}

--- a/src/main/java/com/remind/core/domain/common/exception/FixActivityException.java
+++ b/src/main/java/com/remind/core/domain/common/exception/FixActivityException.java
@@ -1,0 +1,15 @@
+package com.remind.core.domain.common.exception;
+
+import com.remind.core.domain.common.enums.FixActivityErrorCode;
+import lombok.Getter;
+
+@Getter
+public class FixActivityException extends RuntimeException {
+
+    private FixActivityErrorCode errorCode;
+
+    public FixActivityException(FixActivityErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/remind/core/domain/member/Member.java
+++ b/src/main/java/com/remind/core/domain/member/Member.java
@@ -3,7 +3,6 @@ package com.remind.core.domain.member;
 import com.remind.core.domain.member.enums.RolesType;
 import jakarta.persistence.*;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +15,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter

--- a/src/main/java/com/remind/core/domain/member/Member.java
+++ b/src/main/java/com/remind/core/domain/member/Member.java
@@ -2,6 +2,7 @@ package com.remind.core.domain.member;
 
 import com.remind.core.domain.member.enums.RolesType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(value = MemberRegisterListener.class)
 @Table(name = "member", indexes = {@Index(name = "idx_authId", columnList = "authId")})
 public class Member {
 

--- a/src/main/java/com/remind/core/domain/member/MemberRegisterListener.java
+++ b/src/main/java/com/remind/core/domain/member/MemberRegisterListener.java
@@ -1,0 +1,61 @@
+package com.remind.core.domain.member;
+
+import static com.remind.core.domain.common.enums.FixActivityErrorCode.*;
+import static com.remind.core.domain.common.enums.MemberErrorCode.*;
+
+
+import com.remind.core.domain.common.exception.FixActivityException;
+import com.remind.core.domain.common.exception.MemberException;
+import com.remind.core.domain.member.repository.MemberRepository;
+import com.remind.core.domain.mood.Activity;
+import com.remind.core.domain.mood.FixActivity;
+import com.remind.core.domain.mood.repository.ActivityRepository;
+import com.remind.core.domain.mood.repository.FixActivityRepository;
+import jakarta.persistence.PostPersist;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MemberRegisterListener {
+
+    private final FixActivityRepository fixActivityRepository;
+    private final ActivityRepository activityRepository;
+    private final MemberRepository memberRepository;
+    private static final Long FIX_SIZE = 10L;
+
+    public MemberRegisterListener(@Lazy ActivityRepository activityRepository,
+                                  @Lazy FixActivityRepository fixActivityRepository,
+                                  @Lazy MemberRepository memberRepository) {
+        this.activityRepository = activityRepository;
+        this.fixActivityRepository = fixActivityRepository;
+        this.memberRepository = memberRepository;
+
+    }
+
+    //TODO: fixActivityRepository.findAll(); 을 사용하면 에러가 발생하는데 해당 에러를 해결하고 리팩토링 할 것
+    @PostPersist
+    public void persist(Member member) {
+        Member member1 = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        List<FixActivity> fixActivities = new ArrayList<>();
+        for (long i = 1; i <= FIX_SIZE; i++) {
+            fixActivities.add(fixActivityRepository.findById(i)
+                    .orElseThrow(() -> new FixActivityException(FIX_ACTIVITY_NOT_FOUND)));
+        }
+        fixActivities.forEach(activity -> {
+            activityRepository.save(
+                    Activity.builder()
+                            .member(member1)
+                            .activityName(activity.getActivityName())
+                            .activityIcon(activity.getActivityIcon())
+                            .build()
+            );
+        });
+    }
+
+}

--- a/src/main/java/com/remind/core/domain/member/Patient.java
+++ b/src/main/java/com/remind/core/domain/member/Patient.java
@@ -3,13 +3,15 @@ package com.remind.core.domain.member;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EntityListeners(value = PatientRegisterListener.class)
 public class Patient {
 
     @Id

--- a/src/main/java/com/remind/core/domain/member/PatientRegisterListener.java
+++ b/src/main/java/com/remind/core/domain/member/PatientRegisterListener.java
@@ -14,22 +14,20 @@ import com.remind.core.domain.mood.repository.FixActivityRepository;
 import jakarta.persistence.PostPersist;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
-public class MemberRegisterListener {
+public class PatientRegisterListener {
 
     private final FixActivityRepository fixActivityRepository;
     private final ActivityRepository activityRepository;
     private final MemberRepository memberRepository;
     private static final Long FIX_SIZE = 10L;
 
-    public MemberRegisterListener(@Lazy ActivityRepository activityRepository,
-                                  @Lazy FixActivityRepository fixActivityRepository,
-                                  @Lazy MemberRepository memberRepository) {
+    public PatientRegisterListener(@Lazy ActivityRepository activityRepository,
+                                   @Lazy FixActivityRepository fixActivityRepository,
+                                   @Lazy MemberRepository memberRepository) {
         this.activityRepository = activityRepository;
         this.fixActivityRepository = fixActivityRepository;
         this.memberRepository = memberRepository;
@@ -38,8 +36,8 @@ public class MemberRegisterListener {
 
     //TODO: fixActivityRepository.findAll(); 을 사용하면 에러가 발생하는데 해당 에러를 해결하고 리팩토링 할 것
     @PostPersist
-    public void persist(Member member) {
-        Member member1 = memberRepository.findById(member.getId())
+    public void persist(Patient patient) {
+        Member member = memberRepository.findById(patient.getId())
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         List<FixActivity> fixActivities = new ArrayList<>();
@@ -50,7 +48,7 @@ public class MemberRegisterListener {
         fixActivities.forEach(activity -> {
             activityRepository.save(
                     Activity.builder()
-                            .member(member1)
+                            .member(member)
                             .activityName(activity.getActivityName())
                             .activityIcon(activity.getActivityIcon())
                             .build()

--- a/src/main/java/com/remind/core/domain/mood/FixActivity.java
+++ b/src/main/java/com/remind/core/domain/mood/FixActivity.java
@@ -1,0 +1,30 @@
+package com.remind.core.domain.mood;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FixActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "activity_name", nullable = false)
+    private String activityName;
+
+    @Column(name = "activity_icon", nullable = false)
+    private String activityIcon;
+}

--- a/src/main/java/com/remind/core/domain/mood/repository/FixActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/FixActivityRepository.java
@@ -1,12 +1,8 @@
 package com.remind.core.domain.mood.repository;
 
 import com.remind.core.domain.mood.FixActivity;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface FixActivityRepository extends JpaRepository<FixActivity, Long> {
 
-    @Query("select fixActivity from FixActivity fixActivity")
-    List<FixActivity> findAllCustom();
 }

--- a/src/main/java/com/remind/core/domain/mood/repository/FixActivityRepository.java
+++ b/src/main/java/com/remind/core/domain/mood/repository/FixActivityRepository.java
@@ -1,0 +1,12 @@
+package com.remind.core.domain.mood.repository;
+
+import com.remind.core.domain.mood.FixActivity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface FixActivityRepository extends JpaRepository<FixActivity, Long> {
+
+    @Query("select fixActivity from FixActivity fixActivity")
+    List<FixActivity> findAllCustom();
+}


### PR DESCRIPTION
## 📝 작업 내용
 - `@EntityListeners`를 사용하여 Patient 가 생성(회원 가입)될 떄, 고정 활동 10개를 가져와 자동적으로 Activity 엔티티를 생성해주었습니다.

## 💬 ETC.
 - **미흡한 점**
     - `@PostPersist` 안에 영속성 문제인지 다른 문제인지 모르겠지만 `fixActivityRepository.findAll();` 부분에서 에러가 발생하여 일단 for문으로 하나씩 조회하는 것으로 구현했습니다..!

### TODO: #53 master 브랜치로 머진 된 후 `@EntityListeners`를 Member가 아닌 Patient 엔티티로 수정할 예정입니다. >> 수정 완료
## #️⃣ 연관된 이슈
resolves: #55 
