### PR TITLE
Feat/62 현재 날짜 기준으로 연속 며칠동안 기분 생성했는지 조회하는 기능 추가

### DIFF
--- a/src/main/java/com/remind/api/mood/controller/MoodChartController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodChartController.java
@@ -83,13 +83,13 @@ public class MoodChartController {
             content = @Content(
                     mediaType = "application/json",
                     examples = {
-                            @ExampleObject(value = "{\"code\":200, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"maxSeriesDays\": 10}}")
+                            @ExampleObject(value = "{\"code\":200, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"currentSeriesDays\": 10}}")
                     }
             )
     )
     @GetMapping("/series")
     public ResponseEntity<ApiSuccessResponse<?>> getMaxSeries(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(
-                new ApiSuccessResponse<>(Map.of("maxSeriesDays", moodChartService.getMaxSeries(userDetails))));
+                new ApiSuccessResponse<>(Map.of("currentSeriesDays", moodChartService.getCurrentSeries(userDetails))));
     }
 }

--- a/src/main/java/com/remind/api/mood/controller/MoodChartController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodChartController.java
@@ -9,9 +9,12 @@ import com.remind.core.domain.mood.enums.FeelingType;
 import com.remind.core.security.dto.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -69,5 +72,24 @@ public class MoodChartController {
             @Parameter(description = "감정") @RequestParam("feelingType") FeelingType feelingType) {
         return ResponseEntity.ok(
                 new ApiSuccessResponse<>(moodChartService.getActivityPercentChart(userDetails, feelingType)));
+    }
+
+
+    @Operation(
+            summary = "무드 연속 기록 조회 API"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "무드 연속 기록 조회 성공 응답입니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(value = "{\"code\":200, \"message:\": \"정상 처리되었습니다.\", \"data\": {\"maxSeriesDays\": 10}}")
+                    }
+            )
+    )
+    @GetMapping("/series")
+    public ResponseEntity<ApiSuccessResponse<?>> getMaxSeries(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(
+                new ApiSuccessResponse<>(Map.of("maxSeriesDays", moodChartService.getMaxSeries(userDetails))));
     }
 }

--- a/src/main/java/com/remind/api/mood/controller/MoodChartController.java
+++ b/src/main/java/com/remind/api/mood/controller/MoodChartController.java
@@ -88,7 +88,7 @@ public class MoodChartController {
             )
     )
     @GetMapping("/series")
-    public ResponseEntity<ApiSuccessResponse<?>> getMaxSeries(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiSuccessResponse<Map>> getMaxSeries(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(
                 new ApiSuccessResponse<>(Map.of("currentSeriesDays", moodChartService.getCurrentSeries(userDetails))));
     }

--- a/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
@@ -1,0 +1,29 @@
+package com.remind.api.mood.repository;
+
+import com.remind.core.domain.mood.repository.MoodRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MoodConsecutiveRepository extends MoodRepository {
+
+    /**
+     * 날짜(mood_date)를 기준으로 연속인 데이터의 최대 갯수를 구한다. 사용자 정의 변수(@count,@prev_date)를 사용한다. 이때, 날짜 기준으로 정렬된
+     * 테이블(sorted_mood_table)에서 하나의 행씩 가져와 이전 행의 날짜(@prev_date)와 연속인지 비교(DATE_ADD())하여 연속이면 @count를 하나씩 증가시키고 연속이지 않으면
+     * 1로 초기화한다.
+     */
+    @Query(nativeQuery = true, value = """
+            SELECT MAX(COUNT)
+            FROM (
+                SELECT
+                    @count \\:= IF(sorted_mood_table.mood_date = DATE_ADD(@prev_date, INTERVAL 1 DAY), @count + 1, 1) as COUNT,
+                    @prev_date \\:= sorted_mood_table.mood_date as PREV_DATE
+                FROM (
+                        SELECT mood_date
+                        FROM mood m
+                        WHERE m.patient_id = :patientId
+                        ORDER BY m.mood_date
+                        ) AS sorted_mood_table, (SELECT @prev_date \\:= NULL, @count \\:= 1) AS variables
+                ) AS count_table;
+            """)
+    Long getMaxSeries(@Param("patientId") Long patientId);
+}

--- a/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
@@ -4,10 +4,13 @@ import com.remind.core.domain.mood.enums.FeelingType;
 import com.remind.core.domain.mood.repository.MoodRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MoodConsecutiveRepository extends MoodRepository {
+
+    // 밋업데이 MVP 단계에서는 없어진 비즈니스 로직(현재까지 최대 연속 일수)이다.
 
     /**
      * 날짜(mood_date)를 기준으로 연속인 데이터의 최대 갯수를 구한다. 사용자 정의 변수(@count,@prev_date)를 사용한다. 이때, 날짜 기준으로 정렬된
@@ -29,6 +32,31 @@ public interface MoodConsecutiveRepository extends MoodRepository {
                 ) AS count_table;
             """)
     Long getMaxSeries(@Param("patientId") Long patientId);
+
+
+    /**
+     * 현재 날짜부터 시작하여 날짜(mood_date)를 기준으로 연속인 데이터의 갯수를 구한다. 사용자 정의 변수(@count,@prev_date)를 사용한다. 이때, 날짜 기준으로 정렬된
+     * 테이블(sorted_mood_table)에서 하나의 행씩 가져와 이전 행의 날짜(@prev_date)와 연속인지 비교(DATE_SUB())하여 연속이면 @count를 하나씩 증가시키고 연속이지 않으면
+     * NULL로 초기화한다.
+     * 한번 @count 값이 null로 초기화되면(연속 x) 그 아래 데이터들의 COUNT 컬럼은 모두 NULL 값이다.
+     */
+    @Query(nativeQuery = true, value = """
+                 SELECT MAX(count_table.COUNT)
+                 FROM (
+                     SELECT
+                         @count \\:= IF(@count is NOT NULL and sorted_mood_table.mood_date = DATE_SUB(@prev_date, INTERVAL 1 DAY), @count + 1, NULL) as COUNT,
+                         @prev_date \\:= sorted_mood_table.mood_date as PREV_DATE
+                     FROM (
+                             SELECT mood_date
+                             FROM mood m
+                             WHERE m.patient_id = 1
+                             ORDER BY m.mood_date desc
+            ) AS sorted_mood_table, (SELECT @prev_date \\:= DATE_ADD(CURRENT_DATE(), INTERVAL 1 DAY), @count \\:= 0) AS variables
+                     ) AS count_table
+                     WHERE count_table.COUNT IS NOT NULL;
+                 """)
+    Optional<Long> getCurrentSeries(@Param("patientId") Long patientId);
+
 
     /**
      * 오늘 날짜(nowDate)와 기준 날짜(criterionDate)사이의 무드 점수를 조회한다.

--- a/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
+++ b/src/main/java/com/remind/api/mood/repository/MoodConsecutiveRepository.java
@@ -1,6 +1,9 @@
 package com.remind.api.mood.repository;
 
+import com.remind.core.domain.mood.enums.FeelingType;
 import com.remind.core.domain.mood.repository.MoodRepository;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +29,14 @@ public interface MoodConsecutiveRepository extends MoodRepository {
                 ) AS count_table;
             """)
     Long getMaxSeries(@Param("patientId") Long patientId);
+
+    /**
+     * 오늘 날짜(nowDate)와 기준 날짜(criterionDate)사이의 무드 점수를 조회한다.
+     */
+    @Query("select mood.feelingType "
+            + "from Mood mood "
+            + "where mood.patient.id = :patientId and (mood.moodDate between :nowDate and :criterionDate)")
+    List<FeelingType> getMoodFeelingTypes(@Param("patientId") Long patientId,
+                                          @Param("nowDate") LocalDate nowDate,
+                                          @Param("criterionDate") LocalDate criterionDate);
 }

--- a/src/main/java/com/remind/api/mood/service/MoodChartService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartService.java
@@ -6,6 +6,7 @@ import com.remind.api.mood.dto.response.ActivityPercentResponseDto;
 import com.remind.api.mood.dto.response.MoodChartPagingResponseDto;
 import com.remind.api.mood.dto.response.MoodPercentResponseDto;
 import com.remind.api.mood.repository.MoodChartPagingRepository;
+import com.remind.api.mood.repository.MoodConsecutiveRepository;
 import com.remind.core.domain.mood.enums.FeelingType;
 import com.remind.core.security.dto.UserDetailsImpl;
 import java.time.LocalDate;
@@ -23,6 +24,7 @@ public class MoodChartService {
 
     private final MoodChartPagingRepository moodChartPagingRepository;
     private final MoodChartCacheService moodChartCacheService;
+    private final MoodConsecutiveRepository moodConsecutiveRepository;
 
     @Transactional(readOnly = true)
     public MoodChartPagingResponseDto getMoodChart(UserDetailsImpl userDetails, Integer year, Integer month,
@@ -53,6 +55,12 @@ public class MoodChartService {
     public List<ActivityPercentResponseDto> getActivityPercentChart(UserDetailsImpl userDetails,
                                                                     FeelingType feelingType) {
         return moodChartCacheService.getActivityPercentChart(userDetails.getMemberId(), feelingType);
+
+    }
+
+    @Transactional(readOnly = true)
+    public Long getMaxSeries(UserDetailsImpl userDetails) {
+        return moodConsecutiveRepository.getMaxSeries(userDetails.getMemberId());
 
     }
 }

--- a/src/main/java/com/remind/api/mood/service/MoodChartService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartService.java
@@ -59,8 +59,7 @@ public class MoodChartService {
     }
 
     @Transactional(readOnly = true)
-    public Long getMaxSeries(UserDetailsImpl userDetails) {
-        return moodConsecutiveRepository.getMaxSeries(userDetails.getMemberId());
-
+    public Long getCurrentSeries(UserDetailsImpl userDetails) {
+        return moodConsecutiveRepository.getCurrentSeries(userDetails.getMemberId()).orElse(0L);
     }
 }

--- a/src/main/java/com/remind/core/security/config/SecuirityConfig.java
+++ b/src/main/java/com/remind/core/security/config/SecuirityConfig.java
@@ -110,7 +110,8 @@ public class SecuirityConfig {
                 antMatcher(GET, "/taking-medicine/monthly"),
                 antMatcher(POST, "/taking-medicine"),
                 antMatcher(POST, "/alarm"),
-                antMatcher(GET, "/alarm/{prescriptionId}")
+                antMatcher(GET, "/alarm/{prescriptionId}"),
+                antMatcher(GET, "/mood/chart/series")
 
         );
         return requestMatchers.toArray(RequestMatcher[]::new);


### PR DESCRIPTION
## 📝 작업 내용
 - 현재 날짜를 기준으로 연속 며칠동안 기분 생성했는지 조회하는 기능 추가
    - 만약 오늘(현재 날짜)에 오늘의 기분(mood)를 생성하지 않았으면 0으로 반환 되도록 하였습니다.

## 💬 ETC.
 - **REFERENCE**
    - https://wbluke.tistory.com/43
 
- JPA native 쿼리를 사용할 떄 `:=` 부분에서 공백 인식 문제가 존재하여 `\\`를 추가 하였습니다.
  - 인텔리제이 상으론 빨간색 밑줄로 `Bad characters`이라고 뜨는데 정상적으로 실행됩니다. 

## #️⃣ 연관된 이슈
resolves: #62 
