### PR TITLE
fix(#66): element cannot be mapped to a null key 에러 해결

### DIFF
--- a/src/main/java/com/remind/api/mood/service/MoodChartCacheService.java
+++ b/src/main/java/com/remind/api/mood/service/MoodChartCacheService.java
@@ -7,6 +7,7 @@ import com.remind.api.mood.repository.MoodPercentRepository;
 import com.remind.core.domain.mood.enums.FeelingType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class MoodChartCacheService {
 
         // FeelingType 별로 그룹화 이후 각 그룹의 갯수 / 전체 갯수를 계산하고 퍼센트 계산
         feelingResponse.stream()
+                .filter(Objects::nonNull)
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
                 .forEach((feelingType, count) -> {
                     response.add(


### PR DESCRIPTION
## 📝 작업 내용
 - stream 작업 중 key 값으로 null이 주어졌을 때 에러가 발생하여 `.filter(Objects::nonNull)`를 추가해줬습니다.

## 💬 ETC.
 - **기타 공유사항에 대해 작성해 주세요.**

## #️⃣ 연관된 이슈
resolves: #66 
